### PR TITLE
Hoverdialog

### DIFF
--- a/html/slimyet.js
+++ b/html/slimyet.js
@@ -564,7 +564,7 @@ Tooltip.prototype.hover = function(x, y, nofade) {
 
   var h = this.obj.outerHeight();
   var w = this.obj.outerWidth();
-  var pad = 1;
+  var pad = 10;
   // Lower-right of cursor
   var top = y + pad;
   var left = x + pad;


### PR DESCRIPTION
Fixes issue #14 (again untested beyond a little fiddling in firebug to see if this does what I think it does). Note that the first commit should also fix the tooltip always appearing above the mouse cursor rather than what was intended.
