### PR TITLE
Add a proper try mode (#69)

### DIFF
--- a/benchtester/BatchTester.py
+++ b/benchtester/BatchTester.py
@@ -525,10 +525,10 @@ class BatchTest(object):
         builds.append(BuildGetter.TinderboxBuild(startdate))
     elif mode == 'ftp':
       path = batchargs['firstbuild']
-      if path.startswith('try:'):
-        builds.append(BuildGetter.TryBuild(path[4:]))
-      else
-        builds.append(BuildGetter.FTPBuild(path))
+      builds.append(BuildGetter.FTPBuild(path))
+    elif mode == 'try':
+      path = batchargs['firstbuild']
+      builds.append(BuildGetter.TryBuild(path))
     elif mode == 'compile':
       # See https://github.com/mozilla/areweslimyet/issues/47
       raise Exception("Build type 'compile' is not currently supported")

--- a/html/status/request.cgi
+++ b/html/status/request.cgi
@@ -34,17 +34,17 @@ def main():
         or (end and invalidBuild.search(end)):
     error("Invalid input")
 
-  if mode not in [ 'nightly', 'tinderbox', 'compile', 'ftp' ]:
+  if mode not in [ 'nightly', 'tinderbox', 'compile', 'ftp', 'try' ]:
     error("Unknown mode")
 
 
   if series and series.startswith("areweslimyet"):
     error("Series names may not start with areweslimyet")
 
-  if mode == "ftp" and not series:
-    error("FTP builds must use a custom series")
+  if mode in ("ftp", "try") and not series:
+    error("FTP and try builds must use a custom series")
 
-  if mode == "ftp" and not (start.startswith('/pub') or start.startswith('try:')):
+  if mode == "ftp" and not start.startswith('/pub'):
     error("Invalid ftp path");
 
   ret = { "mode": mode, "firstbuild": start }

--- a/html/status/status.js
+++ b/html/status/status.js
@@ -336,9 +336,8 @@ $(function () {
           alert("The try changeset ID must be exactly 12 characters");
           return false;
         }
-        // try is just a ftp build with a path of try:changeset
-        start = "try:" + start;
-        mode = "ftp";
+
+        mode = "try";
       }
 
       var args = { 'mode': mode, 'startbuild': start };

--- a/util/try_watcher.py
+++ b/util/try_watcher.py
@@ -119,8 +119,8 @@ def queue_try_job(rev, series):
     :param series: Name for the series to graph the try push in.
     """
     params = {
-        'mode': 'ftp',
-        'startbuild': 'try:' + rev[:12],
+        'mode': 'try',
+        'startbuild': rev[:12],
         'series': series,
         'prioritize': True
     }
@@ -138,8 +138,8 @@ def queue_try_job(rev, series):
 def write_try_job(rev, series, batch_dir):
     """Writes the try job to the given directory"""
     params = {
-        'mode': 'ftp',
-        'firstbuild': 'try:' + rev[:12],
+        'mode': 'try',
+        'firstbuild': rev[:12],
         'series': series,
         'prioritize': True
     }


### PR DESCRIPTION
Currently we prefix try requests with "try:" to differentiate them from "ftp" requests. This updates try watcher, the cgi script, and the status page to just specify a try mode instead.

@nnethercote can you review this?