### PR TITLE
DB cleanup in preparation of e10s support

### DIFF
--- a/benchtester/BenchTester.py
+++ b/benchtester/BenchTester.py
@@ -164,8 +164,8 @@ class BenchTester():
   def insert_results(self, test_id, results):
     # - results is an array of iterations
     # - iterations is an array of checkpoints
-    # - checkpoint is a dict with: label, memory
-    # - memory is a dict of processes
+    # - checkpoint is a dict with: label, reports
+    # - reports is a dict of processes
     cur = self.sqlite.cursor()
 
     for x, iteration in enumerate(results):
@@ -181,8 +181,8 @@ class BenchTester():
           cur.execute("INSERT INTO benchtester_checkpoints(name) VALUES (?)", (label, ))
           checkpoint_id = cur.lastrowid
 
-        for process_name, memory in checkpoint['memory'].iteritems():
-          # memory is a dictionary of datapoint_name: { val, unit, kind }
+        for process_name, reports in checkpoint['reports'].iteritems():
+          # reports is a dictionary of datapoint_name: { val, unit, kind }
 
           # Strip pid portion of process name
           process_re = r'(.*)\s+\(.*\)'
@@ -200,10 +200,10 @@ class BenchTester():
 
           # insert datapoint names
           insertbegin = time.time()
-          self.info("Inserting %u datapoints into DB" % len(memory))
+          self.info("Inserting %u datapoints into DB" % len(reports))
           cur.executemany("INSERT OR IGNORE INTO `benchtester_datapoints`(name) "
                           "VALUES (?)",
-                          ( [ k ] for k in memory.iterkeys() ))
+                          ( [ k ] for k in reports.iterkeys() ))
           self.sqlite.commit()
           self.info("Filled datapoint names in %.02fs" % (time.time() - insertbegin))
 
@@ -220,7 +220,7 @@ class BenchTester():
                               dp['unit'],
                               dp['kind'],
                               name ]
-                            for name, dp in memory.iteritems() if dp ))
+                            for name, dp in reports.iteritems() if dp ))
           self.sqlite.commit()
           self.info("Filled datapoint values in %.02fs" % (time.time() - insertbegin))
 

--- a/benchtester/MarionetteTest.py
+++ b/benchtester/MarionetteTest.py
@@ -127,23 +127,7 @@ class MarionetteTest(BenchTester.BenchTest):
 
     self.endurance_results = runner.testvars.get("results", [])
 
-    results = list()
-    for x in range(len(self.endurance_results)):
-      iteration = self.endurance_results[x]
-      for checkpoint in iteration:
-        iternum = x + 1
-        label = checkpoint['label']
-        # TODO(ER): Handle all process entries
-        for memtype,memval in checkpoint['memory']['Main'].items():
-          if type(memval) is dict:
-            prefix = memval['unit'] + ":"
-            memval = memval['val']
-          else:
-            prefix = ""
-          datapoint = [ "%s%s" % (prefix, memtype), memval, "%s:%u" % (label, iternum) ]
-          results.append(datapoint)
-
-    if not self.tester.add_test_results(testname, results, not failures):
+    if not self.tester.add_test_results(testname, self.endurance_results, not failures):
       return self.error("Failed to save test results")
     if failures:
       return self.error("%u failures occured during test run" % failures)

--- a/benchtester/checkpoint.js
+++ b/benchtester/checkpoint.js
@@ -26,40 +26,18 @@ function createCheckpoint(aLabel) {
       aProcess = "Main"
     }
 
-    var unitname;
-    switch (aUnits) {
-      // Old builds had no units field and assumed bytes
-      case undefined:
-      case Ci.nsIMemoryReporter.UNITS_BYTES:
-        break;
-      case Ci.nsIMemoryReporter.UNITS_COUNT:
-        unitname = "cnt";
-        break;
-      case Ci.nsIMemoryReporter.UNITS_PERCENTAGE:
-        unitname = "pct";
-        break;
-      default:
-        // Unhandled
-        return;
-    }
-
-    // For types with non-bytes units the value is
-    //   { 'unit': 'percent', 'val': 1234 }
-    // For bytes it is just a number, so as not to bloat output (we end up
-    // exporting 11k+ reporters on newer builds)
     if (!result['memory'][aProcess]) {
       result['memory'][aProcess] = {}
     }
 
     if (result['memory'][aProcess][aPath]) {
-      if (unitname)
-        result['memory'][aProcess][aPath]['val'] += aAmount;
-      else
-        result['memory'][aProcess][aPath] += aAmount;
-    } else if (unitname) {
-      result['memory'][aProcess][aPath] = { 'unit': unitname, 'val': aAmount };
+      result['memory'][aProcess][aPath]['val'] += aAmount;
     } else {
-      result['memory'][aProcess][aPath] = aAmount;
+      result['memory'][aProcess][aPath] = {
+        'unit': aUnits,
+        'val': aAmount,
+        'kind': aKind
+      };
     }
 
     if (aKind !== undefined && aKind == Ci.nsIMemoryReporter.KIND_HEAP

--- a/benchtester/checkpoint.js
+++ b/benchtester/checkpoint.js
@@ -70,6 +70,8 @@ function createCheckpoint(aLabel) {
   var memMgr = Cc["@mozilla.org/memory-reporter-manager;1"].
       getService(Ci.nsIMemoryReporterManager);
 
+  // NB: |memMgr.getReports| was added in Fx28, we do not support releases
+  //     prior to that.
   memMgr.getReports(addReport, null, onFinish, null, /* anonymize */ false);
 }
 

--- a/benchtester/checkpoint.js
+++ b/benchtester/checkpoint.js
@@ -13,7 +13,7 @@ function createCheckpoint(aLabel) {
   var result = {
     label: aLabel,
     timestamp: new Date(),
-    memory: {},
+    reports: {},
   };
 
   var knownHeap = {};
@@ -26,14 +26,14 @@ function createCheckpoint(aLabel) {
       aProcess = "Main"
     }
 
-    if (!result['memory'][aProcess]) {
-      result['memory'][aProcess] = {}
+    if (!result['reports'][aProcess]) {
+      result['reports'][aProcess] = {}
     }
 
-    if (result['memory'][aProcess][aPath]) {
-      result['memory'][aProcess][aPath]['val'] += aAmount;
+    if (result['reports'][aProcess][aPath]) {
+      result['reports'][aProcess][aPath]['val'] += aAmount;
     } else {
-      result['memory'][aProcess][aPath] = {
+      result['reports'][aProcess][aPath] = {
         'unit': aUnits,
         'val': aAmount,
         'kind': aKind
@@ -56,11 +56,11 @@ function createCheckpoint(aLabel) {
    */
   function onFinish(aClosure) {
     // Calculate heap-unclassified for each process
-    var keys = Object.keys(result['memory']);
+    var keys = Object.keys(result['reports']);
     for (var idx = 0; idx < keys.length; idx++) {
       let proc = keys[idx];
-      result['memory'][proc]['explicit/heap-unclassified'] = 
-          result['memory'][proc]['heap-allocated'] - knownHeap[proc];
+      result['reports'][proc]['explicit/heap-unclassified'] =
+          result['reports'][proc]['heap-allocated'] - knownHeap[proc];
     }
 
     marionetteScriptFinished(result);

--- a/util/update_database.py
+++ b/util/update_database.py
@@ -89,6 +89,9 @@ if has_datapoints and has_meta:
   print("Database is already the newest format!")
   sys.exit(1)
 
+# Explicitly set the new version to 0.
+cur.execute("INSERT INTO `benchtester_version` (`version`) VALUES (?)", [ 0 ])
+
 # Copy all non-excluded tests
 # (this was added so I could drop the obsolete Slimtest-TalosTP5 test from old DBs)
 

--- a/util/update_database_v0_v1.py
+++ b/util/update_database_v0_v1.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright © 2012 Mozilla Corporation
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+# Converts a database using the older unversioned format to the v1 format.
+
+import os
+import re
+import sqlite3
+import sys
+import time
+
+sys.path.append(os.path.join('.', 'benchtester'))
+
+# We need gTableSchemas to create the new database
+try:
+  import BenchTester
+except:
+  sys.stderr.write("Couldn't find benchtester in current directory. Run me from the root!\n");
+  sys.exit(1);
+
+
+# memory report 'kind' constants
+KIND_NONHEAP = 0
+KIND_HEAP = 1
+KIND_OTHER = 2
+
+# memory report 'units' constants
+UNITS_BYTES = 0
+UNITS_COUNT = 1
+UNITS_COUNT_CUMULATIVE = 2
+UNITS_PERCENTAGE = 3
+
+if len(sys.argv) < 2:
+  sys.stderr.write("Usage: %s <database>\n" % (sys.argv[0],));
+  sys.stderr.write("  will create a new database named <database>.new in the\n");
+  sys.stderr.write("  newer format. The optional second parameter is one or\n");
+  sys.stderr.write("  more tests (by name) to omit from the new database.\n");
+  sys.exit(1);
+
+if not os.path.exists(sys.argv[1]):
+  sys.stderr.write("Database '%s' does not exist" % (sys.argv[1],))
+  sys.exit(1)
+
+newdb = sys.argv[1] + '.new'
+print("Creating %s..." % (newdb,))
+sql = sqlite3.connect(newdb, timeout=900)
+sql.row_factory = sqlite3.Row
+cur = sql.cursor()
+for schema in BenchTester.gTableSchemas:
+  print(schema)
+  cur.execute(schema)
+
+# This will speed things up significantly at the expense of ~4GiB memory usage
+cur.execute('''PRAGMA cache_size = -4000000''')
+cur.execute('''PRAGMA temp_store = 2''')
+# The new database is empty if we don't reach COMMIT, so we don't particularly
+# care if we corrupt it. This also significantly speeds up the operation.
+cur.execute('''PRAGMA journal_mode = OFF''')
+cur.execute('''PRAGMA synchronous = OFF''')
+
+# Open old db
+print("Opening %s..." % (sys.argv[1],))
+cur.execute('''ATTACH DATABASE ? AS old''', [ sys.argv[1] ])
+
+print("Counting rows...")
+cur.execute('SELECT COUNT(*) FROM old.benchtester_tests')
+totalrows = cur.fetchone()[0]
+print("%u total tests" % totalrows)
+
+#
+# Determine format of old DB
+#
+
+db_version = None
+try:
+  cur.execute('SELECT * FROM old.benchtester_version LIMIT 1')
+  db_version = cur.fetchone()['version']
+except sqlite3.OperationalError:
+  db_version = 0
+
+if db_version == BenchTester.gVersion:
+  print("Database is up to date, version = %s" % db_version)
+  sys.exit(1)
+elif db_version != 0 or BenchTester.gVersion != 1:
+  print("This script currently only handles 0 => 1")
+  sys.exit(1)
+else:
+  print("Upgrading db version from %s to %s" % (db_version, BenchTester.gVersion))
+
+starttime = time.time()
+
+# Set the DB version
+cur.execute('INSERT INTO benchtester_version(version) VALUES ( ? )', (BenchTester.gVersion, ))
+
+# Add the benchtester_checkpoints
+cur.execute('SELECT DISTINCT meta FROM old.benchtester_data')
+checkpoints = set([ row['meta'].split(':')[0] for row in cur.fetchall() ])
+cur.executemany('INSERT INTO benchtester_checkpoints(name) '
+                'VALUES (?)', ( [ checkpoint ] for checkpoint in checkpoints ))
+
+print("[%.02fs] Inserted %d checkpoints" % ((time.time() - starttime), len(checkpoints)))
+
+# Add an entry for Main in benchtester_procs
+cur.execute('INSERT INTO benchtester_procs(name) VALUES ( ? )', ('Main', ))
+
+# Fill in the datapoints table
+cur.execute('SELECT DISTINCT name AS datapoint '
+            'FROM old.benchtester_datapoints d ')
+
+# Given an old datapoint name, returns [ newname, units ]
+def splitunits(dp):
+  units = UNITS_BYTES
+  match = re.match(r'(cnt|pct):(.*)', dp)
+
+  if match:
+    dp = match.group(2)
+    units = UNITS_COUNT if match.group(1) == 'cnt' else UNITS_PERCENTAGE
+
+  return [ dp, units ]
+
+datapoints = set(( splitunits(row['datapoint'])[0] for row in cur.fetchall() ))
+
+print("[%.02fs] Selected %d datapoints" % ((time.time() - starttime), len(datapoints)))
+
+# Insert all datapoint names
+cur.executemany('INSERT OR IGNORE INTO benchtester_datapoints(name) '
+                'VALUES (?)',
+                ( [ dp ] for dp in datapoints ))
+
+print("[%.02fs] Inserted %d datapoints" % ((time.time() - starttime), len(datapoints)))
+
+# Copy the builds table
+cur.execute('INSERT INTO benchtester_builds(id, name, time) '
+            'SELECT id, name, time from old.benchtester_builds ')
+
+print("[%.02fs] Copied benchtester_builds" % (time.time() - starttime))
+
+# Copy the tests table
+cur.execute('INSERT INTO benchtester_tests(id, name, time, build_id, successful) '
+            'SELECT id, name, time, build_id, successful FROM old.benchtester_tests')
+
+print("[%.02fs] Copied benchtester_tests" % (time.time() - starttime))
+
+# Fill in the new benchtester_data table
+data = cur.execute('SELECT d.test_id, p.name AS datapoint, d.value, d.meta '
+                   'FROM old.benchtester_data d '
+                   'JOIN old.benchtester_datapoints p '
+                   'ON d.datapoint_id = p.id ')
+
+def splitmeta(meta):
+  return meta.split(':')
+
+def rowify(row):
+  dp, units = splitunits(row['datapoint'])
+  checkpoint, iteration = splitmeta(row['meta'])
+  proc_id = 1 # there's just the Main process in version 0
+
+  # we just say kind is heap if under explicit, other if not
+  kind = KIND_HEAP if dp.startswith('explicit') else KIND_OTHER
+
+  return [ row['test_id'],
+           proc_id,
+           int(iteration),
+           row['value'],
+           units,
+           kind,
+           dp,
+           checkpoint ]
+
+# Insert data
+cur.executemany('INSERT INTO benchtester_data(test_id,datapoint_id,checkpoint_id,proc_id,iteration,value,units,kind) '
+                'SELECT ?, p.id, c.id, ?, ?, ?, ?, ? '
+                'FROM benchtester_datapoints p, '
+                '     benchtester_checkpoints c '
+                'WHERE p.name = ? AND c.name = ?',
+                ( rowify(row) for row in data.fetchall() ))
+
+print("[%.02fs] Inserted benchtester_data" % (time.time() - starttime))
+
+sql.commit()
+
+print("[%.02fs] Committed everything" % (time.time() - starttime))
+


### PR DESCRIPTION
This adds further DB normalization (process table, checkpoint table), removes the metadata column, adds columns for process, checkpoint, iteration and kind.

`create_graph_json.py` is updated to handled the new DB format, but still only generates data for the main process.

@Nephyrin can you take a look?