### PR TITLE
Update window handles after opening a new tab

### DIFF
--- a/benchtester/test_memory_usage.py
+++ b/benchtester/test_memory_usage.py
@@ -245,6 +245,7 @@ class TestMemoryUsage(MarionetteTestCase):
         """
         page_to_load = self._urls[self._pages_loaded % len(self._urls)]
         tabs_loaded = len(self._tabs)
+        is_new_tab = False
 
         if tabs_loaded < self._maxTabs and tabs_loaded <= self._pages_loaded:
             full_tab_list = self.marionette.window_handles
@@ -265,6 +266,8 @@ class TestMemoryUsage(MarionetteTestCase):
             self._tabs.append(new_tabs[0])
             tabs_loaded += 1
 
+            is_new_tab = True
+
         tab_idx = self._pages_loaded % self._maxTabs
 
         tab = self._tabs[tab_idx]
@@ -281,6 +284,16 @@ class TestMemoryUsage(MarionetteTestCase):
             self.logger.info("loading %s" % page_to_load)
             self.marionette.navigate(page_to_load)
             self.logger.debug("loaded!")
+
+        # On e10s the tab handle can change after actually loading content
+        if is_new_tab:
+          # First build a set up w/o the current tab
+          old_tabs = set(self._tabs)
+          old_tabs.remove(tab)
+          # Perform a set diff to get the (possibly) new handle
+          [new_tab] = set(self.marionette.window_handles) - old_tabs
+          # Update the tab list at the current index to preserve the tab ordering
+          self._tabs[tab_idx] = new_tab
 
         # give the page time to settle
         time.sleep(self._perTabPause)


### PR DESCRIPTION
It's possible for the window handle to change after opening a new tab
and then navigating to a real URL when e10s is enabled.