### PR TITLE
Convert tinderbox build links from ftp:// to https://

### DIFF
--- a/faq/faq.md
+++ b/faq/faq.md
@@ -199,7 +199,7 @@ If you don't want to file a bug, find us on IRC (irc.mozilla.org, \#memshrink),
 send smoke signals...do something!  We need your help, particularly in this
 case.
 
-[tinderbox builds]: ftp://ftp.mozilla.org/pub/mozilla.org/firefox/tinderbox-builds/mozilla-inbound-linux64/
+[tinderbox builds]: https://ftp.mozilla.org/pub/mozilla.org/firefox/tinderbox-builds/mozilla-inbound-linux64/
 [nightly builds]: http://nightly.mozilla.org/
 [IRC]: https://wiki.mozilla.org/IRC
 [tbpl]: https://tbpl.mozilla.org/

--- a/html/status/index.htm
+++ b/html/status/index.htm
@@ -48,7 +48,7 @@
         <p>Start Time and Stop Time can be unix timestamps or dates Date.parse recognizes (e.g. "Jan 1 2013 4:00")</p>
       </div>
       <div class="modeTinderbox single note">
-        Build an exact build available at <a href="ftp://ftp.mozilla.org/pub/firefox/tinderbox-builds/mozilla-inbound-linux64/">ftp://ftp.mozilla.org/pub/firefox/tinderbox-builds/mozilla-inbound-linux64/</a>
+        Build an exact build available at <a href="https://ftp.mozilla.org/pub/firefox/tinderbox-builds/mozilla-inbound-linux64/">ftp://ftp.mozilla.org/pub/firefox/tinderbox-builds/mozilla-inbound-linux64/</a>
       </div>
       <div class="modeTinderbox note">
         These are usually auto-queued by the cron job, so this is mainly useful for forcing re-tests.


### PR DESCRIPTION
The FTP-Protocol has recently been disabled on ftp.mozilla.org.