### PR TITLE
Support submitting perf data to prod and staging (#115)

### DIFF
--- a/awsy-template.cfg
+++ b/awsy-template.cfg
@@ -6,3 +6,8 @@ password = password
 host = local.treeherder.mozilla.org
 client_id = client_id
 client_secret = client_secret
+
+[treeherder_staging]
+host = treeherder.allizom.org
+client_id = client_id
+client_secret = client_secret


### PR DESCRIPTION
This splits out the logic to filter revisions so that we can reuse the
submission code for multiple treeherder clients. Submission to an
optional 'treeherder_staging' target is added.

@nnethercote Does this look reasonable to you?