### PR TITLE
Use a single mozlog for each test (#116)

### DIFF
--- a/benchtester/MarionetteTest.py
+++ b/benchtester/MarionetteTest.py
@@ -72,20 +72,15 @@ class MarionetteTest(BenchTester.BenchTest):
       "image.mem.surfacecache.min_expiration_ms": 10000
     }
 
-    # Setup a test runner with our prefs and a default logger.
+    # Setup a test runner with our prefs and our logger.
     # TODO(ER): We might want to use a larger set of "automation" preferences
     #           until marionette sets them for us. See bug 1123683.
     profile = mozprofile.FirefoxProfile(preferences=prefs)
 
-    debug = testvars.get("debug", False)
-    if debug:
-      commandline.formatter_option_defaults['level'] = 'debug'
-
-    logger = commandline.setup_logging("MarionetteTest", {})
     runner = MarionetteTestRunner(
                     binary=self.tester.binary,
                     profile=profile,
-                    logger=logger,
+                    logger=self.parent.logger,
                     address="localhost:%d" % self.port,
                     gecko_log=self.gecko_log,
                     startup_timeout=60)

--- a/run_slimtest.py
+++ b/run_slimtest.py
@@ -7,6 +7,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import argparse
 import os
 import sys
 
@@ -14,16 +15,22 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), "benc
 
 execfile(os.path.join(os.path.dirname(sys.argv[0]), "slimtest_config.py"))
 
+# First parse the args, just looking for a log file.
+parser = argparse.ArgumentParser(add_help=False)
+parser.add_argument('-l', '--logfile', default=None)
+args, _ = parser.parse_known_args()
+logfile = args.logfile
+
 # Load
 import BenchTester
-tester = BenchTester.BenchTester()
+tester = BenchTester.BenchTester(logfile)
 
 # Load modules for tests we have
 for test in AreWeSlimYetTests.values():
   if not tester.load_module(test['type']):
     sys.exit(1)
 
-# Parse command line arguments
+# Parse command line arguments now that all the modules are loaded.
 args = tester.parse_args(sys.argv[1:])
 if not args or not tester.setup(args):
   sys.exit(1)

--- a/slimtest_batchtester_hook.py
+++ b/slimtest_batchtester_hook.py
@@ -83,18 +83,18 @@ def should_test(build, args):
 def run_tests(build, args):
   import BenchTester
 
-  tester = BenchTester.BenchTester()
-  # Load modules for tests we have
-  for test in AreWeSlimYetTests.values():
-    if not tester.load_module(test['type']):
-      raise Exception("Could not load module %s" % (test['type'],))
-
   if args.get('logdir'):
     logfile = os.path.join(args.get('logdir'), "%s.test.log" % (build.revision,))
     gecko_logfile = os.path.join(args.get('logdir'), "%s.gecko.log" % (build.revision,))
   else:
     logfile = None
     gecko_logfile = None
+
+  tester = BenchTester.BenchTester(logfile)
+  # Load modules for tests we have
+  for test in AreWeSlimYetTests.values():
+    if not tester.load_module(test['type']):
+      raise Exception("Could not load module %s" % (test['type'],))
 
   tester.setup({
     'buildname': build.revision,


### PR DESCRIPTION
This unifies the log used by BenchTester, BenchTest, MarionetteTest, and
test_memory_usage. It defaults to mach-style output and switches over to
using "raw" logs (aka structured logging) if a logfile is specified.

This gives a much more thorough test log as the output from the marionette test is included.

@nnethercote can you take a look?