### PR TITLE
Store logs in S3 and report them to treeherder (#116)

### DIFF
--- a/awsy-template.cfg
+++ b/awsy-template.cfg
@@ -11,3 +11,8 @@ client_secret = client_secret
 host = treeherder.allizom.org
 client_id = client_id
 client_secret = client_secret
+
+[S3]
+bucket = awsy
+access_key_id = access_key_id
+access_secret_key = access_secret_key


### PR DESCRIPTION
This adds support for posting the logs for a test run to S3 and
treeherder. Both the unit test log and gecko log (what's actually output
from the Firefox session) are included.

Logs are stored under the following path:
    `http://<S3_bucket>/<repo>/<revision>/<guid>/`

@nnethercote Can you take a look?