### PR TITLE
Better handling for perf job failures

### DIFF
--- a/util/process_perf_data.py
+++ b/util/process_perf_data.py
@@ -245,7 +245,7 @@ def create_treeherder_job(repo, revision, client, nodes, s3=None):
 
         # To avoid overwriting existing data (perhaps if a job is retriggered)
         # the job guid is included in the key.
-        log_prefix = "%s/%s/%s" % (repo, revision, str(uuid.uuid4()))
+        log_prefix = "%s/%s/%s" % (repo, revision, job_guid.hexdigest())
 
         # Add the test log.
         log_id = '%s/%s' % (log_prefix, 'awsy_test_raw.log')

--- a/util/process_perf_data.py
+++ b/util/process_perf_data.py
@@ -5,6 +5,7 @@
 
 import ConfigParser
 import gzip
+import hashlib
 import json
 import math
 import os
@@ -207,8 +208,6 @@ def create_treeherder_job(repo, revision, client, nodes, s3=None):
     tj.add_tier(2)
     tj.add_revision_hash(rev_hash)
     tj.add_project(repo)
-    job_guid = str(uuid.uuid4())
-    tj.add_job_guid(job_guid)
 
     tj.add_job_name('awsy 1')
     tj.add_job_symbol('a1')
@@ -229,7 +228,14 @@ def create_treeherder_job(repo, revision, client, nodes, s3=None):
     tj.add_option_collection({'opt': True})
 
     perf_blob = create_perf_data(nodes)
-    tj.add_artifact('performance_data', 'json', json.dumps({ 'performance_data': perf_blob }))
+    perf_data = json.dumps({ 'performance_data': perf_blob })
+    tj.add_artifact('performance_data', 'json', perf_data)
+
+    # Set the job guid to a combination of the revision and the job data. This
+    # gives us a reasonably unique guid, but is also reproducible for the same
+    # set of data.
+    job_guid = hashlib.sha1(revision + perf_data)
+    tj.add_job_guid(job_guid.hexdigest())
 
     # If an S3 connection is provided the logs for this revision are uploaded.
     # Addtionally a 'Job Info' blob is built up with links to the logs that
@@ -239,7 +245,7 @@ def create_treeherder_job(repo, revision, client, nodes, s3=None):
 
         # To avoid overwriting existing data (perhaps if a job is retriggered)
         # the job guid is included in the key.
-        log_prefix = "%s/%s/%s" % (repo, revision, job_guid)
+        log_prefix = "%s/%s/%s" % (repo, revision, str(uuid.uuid4()))
 
         # Add the test log.
         log_id = '%s/%s' % (log_prefix, 'awsy_test_raw.log')
@@ -282,14 +288,17 @@ def post_treeherder_jobs(client, revisions, s3=None):
             print "Failed to generate data for %s: %s, probably still running" % (revision, e)
             continue
 
-        # NB: In theory we could batch these, but each collection has to be from
-        #     the same repo and it's possible we have different repos in our
-        #     dataset.
-        client.post_collection(repo, tjc)
-        #print tjc.to_json()
+        try:
+            # NB: In theory we could batch these, but each collection has to be from
+            #     the same repo and it's possible we have different repos in our
+            #     dataset.
+            client.post_collection(repo, tjc)
+            #print tjc.to_json()
 
-        successful.append(revision)
-        print "Submitted perf data for %s to %s" % (revision, client.host)
+            successful.append(revision)
+            print "Submitted perf data for %s to %s" % (revision, client.host)
+        except Exception as e:
+            print "Failed to submit data for %s: %s" % (revision, e)
 
     return successful
 


### PR DESCRIPTION
The job guid is now comprised of a hash of the revision and perfdata.
This helps treeherder understand if we are reposting the same job data.

The job posting logic is also updated to continue processing other
builds even if there is a failure posting the current job.