### PR TITLE
Update to treeherder-client 3.0.0

### DIFF
--- a/awsy-template.cfg
+++ b/awsy-template.cfg
@@ -3,12 +3,12 @@ user = user_name
 password = password
 
 [treeherder]
-host = local.treeherder.mozilla.org
+server_url = http://local.treeherder.mozilla.org
 client_id = client_id
 client_secret = client_secret
 
 [treeherder_staging]
-host = treeherder.allizom.org
+server_url = https://treeherder.allizom.org
 client_id = client_id
 client_secret = client_secret
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ marionette-client
 mercurial
 mozdownload
 MozillaPulse
-treeherder-client
+treeherder-client>=3.0.0

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,6 @@ setup(
       "mercurial",
       "mozdownload",
       "MozillaPulse",
-      "treeherder-client"
+      "treeherder-client>=3.0.0"
     ],
 )


### PR DESCRIPTION
Notable changes:
* Performance benefit from connection pooling, if the same `TreeherderClient` instance is re-used for multiple requests.
* The separate `host` and `protocol` arguments have been combined into a single `server_url` argument.

See here for more details:
https://bugzilla.mozilla.org/show_bug.cgi?id=1286240