### PR TITLE
Just use the e10s flag instead of prefs

### DIFF
--- a/benchtester/MarionetteTest.py
+++ b/benchtester/MarionetteTest.py
@@ -63,18 +63,8 @@ class MarionetteTest(BenchTester.BenchTest):
             'startup.homepage_override_url': '',
             'browser.newtab.url': 'about:blank',
 
-            # make sure e10s is enabled
-            "browser.tabs.remote.autostart": e10s,
-            "browser.tabs.remote.autostart.1": e10s,
-            "browser.tabs.remote.autostart.2": e10s,
-            "browser.tabs.remote.autostart.3": e10s,
-            "browser.tabs.remote.autostart.4": e10s,
-            "browser.tabs.remote.autostart.5": e10s,
-            "browser.tabs.remote.autostart.6": e10s,
+            # Set the number of content processes.
             "dom.ipc.processCount": self.process_count,
-
-            # prevent "You're using e10s!" dialog from showing up
-            "browser.displayedE10SNotice": 1000,
 
             # We're not testing flash memory usage. Also: it likes to crash in
             # VNC sessions.
@@ -99,7 +89,8 @@ class MarionetteTest(BenchTester.BenchTest):
             logger=self.parent.logger,
             address="localhost:%d" % self.port,
             gecko_log=self.gecko_log,
-            startup_timeout=60)
+            startup_timeout=60,
+            e10s=e10s)
 
         # Add test
         testpath = os.path.join(*testvars['test'])

--- a/benchtester/MarionetteTest.py
+++ b/benchtester/MarionetteTest.py
@@ -12,7 +12,7 @@ import os
 import shutil
 
 import mozprofile
-from marionette.runtests import MarionetteTestRunner
+from marionette_harness.runtests import MarionetteTestRunner
 
 
 class MarionetteTest(BenchTester.BenchTest):

--- a/benchtester/test_memory_usage.py
+++ b/benchtester/test_memory_usage.py
@@ -6,7 +6,7 @@ import time
 import os
 import sys
 
-from marionette import MarionetteTestCase
+from marionette_harness import MarionetteTestCase
 from marionette_driver import Actions
 from marionette_driver.errors import JavascriptException, ScriptTimeoutException
 import mozlog.structured

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto==2.39.0
-marionette-client==3.1.0
+marionette-harness=4.0.0
 mercurial==3.2.4
 mozdownload==1.20.2
 MozillaPulse==1.0.1

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     packages=["benchtester"],
     install_requires=[
       "boto",
-      "marionette-client",
+      "marionette-harness",
       "mercurial",
       "mozdownload",
       "MozillaPulse",


### PR DESCRIPTION
This uses MarionetteTestRunner's e10s flag instead of our hardcoded pref names. Additionally issue #130 is fixed. 